### PR TITLE
Bump travis xcode version to build swift 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 os:
   - linux
   - osx
-osx_image: xcode10
+osx_image: xcode10.2
 dist: trusty
-sudo: required
 language: generic
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"; fi


### PR DESCRIPTION
The travis build has been failing because the Xcode image did not support swift 5. I've increase the Xcode version for the travis build to get that pretty green successful build badge.